### PR TITLE
fix(android): armeabi-v7a rlottie link failure (undefined pixman NEON asm)

### DIFF
--- a/third_party/rlottie_build/CMakeLists.txt
+++ b/third_party/rlottie_build/CMakeLists.txt
@@ -73,4 +73,9 @@ target_link_libraries(rlottie
                         ${OSSPEC_LIBS}
                      )
 
+if (CMAKE_ANDROID_ARCH_ABI STREQUAL "armeabi-v7a"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|armv7)")
+    target_compile_options(rlottie PRIVATE -U__ARM_NEON__)
+endif()
+
 add_subdirectory(${RLOTTIE}/src "${CMAKE_CURRENT_BINARY_DIR}/rlottie_src")

--- a/third_party/rlottie_build/KOMET_NOTES.md
+++ b/third_party/rlottie_build/KOMET_NOTES.md
@@ -51,6 +51,16 @@ loops. Web has no native path and falls back to the pure-Dart `lottie` player.
   `DynamicLibrary.open('rlottie.framework/rlottie')`.
 - **Windows:** rlottie builds with `/EHs-c- /GR-` and links `Shlwapi.lib` (set in
   `CMakeLists.txt`).
-- **32-bit ARM:** the pixman NEON `.S` asm is not wired; armv7 uses the C path.
+- **32-bit ARM (armeabi-v7a):** the compiler predefines `__ARM_NEON__`, which pulls
+  in `vdrawhelper_neon.cpp`'s hand-written NEON blitter. That blitter calls
+  `pixman_composite_*_asm_neon`, defined only in `pixman-arm-neon-asm.S`. Upstream
+  gates that `.S` behind the CMake var `ARCH == arm` (set by its meson/top-level
+  build, which this glue bypasses), so the symbols are undefined and the armv7 link
+  fails. Wiring the `.S` back in is a dead end on NDK r28: it's GNU-assembler syntax
+  that LLVM's integrated assembler rejects, and the NDK no longer ships GNU `as`
+  (`-fno-integrated-as` has no fallback). So `CMakeLists.txt` here passes
+  `-U__ARM_NEON__` for 32-bit ARM, which drops the hand-asm path and lets the C
+  fallback (`memfill32` in `vdrawhelper.cpp`, guarded by the same macro) take over.
+  The C loops still auto-vectorize to NEON via `-mfpu=neon`.
 - **Bumping rlottie:** `cd third_party/rlottie && git checkout <newsha>`, rebuild,
   then re-check `apple/config.h` and the podspec source globs still match upstream.


### PR DESCRIPTION
## Проблема

Последний **Build Android (FCM)** ([run 29113080379](https://github.com/KometTeam/Komet/actions/runs/29113080379)) упал на линковке `librlottie.so` для **armeabi-v7a**:

```
ld.lld: error: undefined symbol: pixman_composite_src_n_8888_asm_neon
ld.lld: error: undefined symbol: pixman_composite_over_n_8888_asm_neon
>>> referenced by vdrawhelper_neon.cpp
```

Это первая FCM-сборка после перехода на rlottie (коммит 968a30a) — раньше падений не было, потому что rlottie в сборке ещё не было. arm64 линкуется нормально, ломается только 32-битный ARM.

## Причина

- На armeabi-v7a компилятор предопределяет `__ARM_NEON__`, из-за чего компилируется `vdrawhelper_neon.cpp` с ручным NEON-блиттером.
- Блиттер зовёт `pixman_composite_*_asm_neon`, которые определены только в `pixman-arm-neon-asm.S`.
- Upstream добавляет этот `.S` только при `ARCH == arm` (переменная задаётся в meson/верхнем CMakeLists, которые наша склейка `rlottie_build/` обходит) → символы не определены → линк падает.
- Подключить `.S` обратно — тупик на NDK r28: это GNU-ассемблерный синтаксис, который отвергает integrated assembler LLVM, а GNU `as` в NDK больше нет (`-fno-integrated-as` без фолбэка).

## Фикс

Для 32-битного ARM передаём `-U__ARM_NEON__` — ручной asm-путь выпадает, включается C-фолбэк (`memfill32` в `vdrawhelper.cpp`, под тем же макросом). C-циклы всё равно авто-векторизуются в NEON через `-mfpu=neon`. arm64/x86_64 не затронуты.

## Проверка

Локально с тем же **NDK 28.2.13676358**, что в CI:

- ✅ `armeabi-v7a` — `librlottie.so` линкуется, undefined pixman-символов нет, `memfill32` определён из C-фолбэка
- ✅ `arm64-v8a` — линкуется как раньше, без изменений

🤖 Generated with [Claude Code](https://claude.com/claude-code)