### PR TITLE
fix: пропорции фото, отступы подписей, краш редактирования + автозаглавные буквы → dev/0.5.0

### DIFF
--- a/lib/core/media/gallery_source.dart
+++ b/lib/core/media/gallery_source.dart
@@ -23,6 +23,35 @@ class PickedPhoto {
   const PickedPhoto({required this.item, this.editedFile});
 }
 
+class CameraGalleryItem implements GalleryItem {
+  final File file;
+  (int, int)? _dimensions;
+
+  CameraGalleryItem(this.file);
+
+  @override
+  String get id => file.path;
+
+  @override
+  bool get isVideo => false;
+
+  @override
+  Duration? get duration => null;
+
+  @override
+  File? get localFile => file;
+
+  @override
+  Future<Uint8List?> thumbnail(int size) => file.readAsBytes();
+
+  @override
+  Future<File?> originFile() async => file;
+
+  @override
+  Future<(int, int)?> dimensions() async =>
+      _dimensions ??= await imageFileDimensions(file);
+}
+
 Future<(int, int)?> imageFileDimensions(File file) async {
   ui.ImmutableBuffer? buffer;
   ui.ImageDescriptor? descriptor;

--- a/lib/frontend/screens/chats/chat/view/composer_input.dart
+++ b/lib/frontend/screens/chats/chat/view/composer_input.dart
@@ -192,6 +192,8 @@ class ComposerInputBar extends StatelessWidget {
                                         ),
                                         maxLines: null,
                                         keyboardType: TextInputType.multiline,
+                                        textCapitalization:
+                                            TextCapitalization.sentences,
                                         textAlignVertical:
                                             TextAlignVertical.center,
                                         contextMenuBuilder: contextMenuBuilder,

--- a/lib/frontend/screens/chats/chat_screen.dart
+++ b/lib/frontend/screens/chats/chat_screen.dart
@@ -2256,75 +2256,28 @@ class _ChatScreenState extends State<ChatScreen>
 
   Future<void> _startEditMessage(CachedMessage message) async {
     final cs = Theme.of(context).colorScheme;
-    final controller = RichMessageController(text: message.text ?? '')
-      ..setFormatRanges(message.formatRanges);
 
-    final saved = await showModalBottomSheet<bool>(
+    final content = await showModalBottomSheet<
+      ({String text, List<Map<String, dynamic>> elements})
+    >(
       context: context,
       isScrollControlled: true,
       backgroundColor: cs.surfaceContainerHigh,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
-      builder: (sheetContext) => Padding(
-        padding: EdgeInsets.only(
-          left: 20,
-          right: 20,
-          top: 20,
-          bottom: MediaQuery.viewInsetsOf(sheetContext).bottom + 20,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              'Изменить сообщение',
-              style: TextStyle(
-                color: cs.onSurface,
-                fontSize: 18,
-                fontWeight: FontWeight.w600,
-                fontFamily: 'Outfit',
-              ),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: controller,
-              autofocus: true,
-              minLines: 1,
-              maxLines: 6,
-              style: TextStyle(color: cs.onSurface),
-              contextMenuBuilder: (ctx, state) =>
-                  _formatContextMenu(controller, ctx, state),
-              decoration: InputDecoration(
-                hintText: 'Текст сообщения',
-                filled: true,
-                fillColor: cs.surfaceContainerHighest,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(14),
-                  borderSide: BorderSide.none,
-                ),
-              ),
-            ),
-            const SizedBox(height: 20),
-            FilledButton(
-              onPressed: () => Navigator.of(sheetContext).pop(true),
-              child: const Text('Сохранить'),
-            ),
-          ],
-        ),
+      builder: (sheetContext) => _EditMessageSheet(
+        text: message.text ?? '',
+        formatRanges: message.formatRanges,
+        contextMenuBuilder: _formatContextMenu,
       ),
     );
 
-    if (saved != true || !mounted) {
-      controller.dispose();
-      return;
-    }
+    if (content == null || !mounted) return;
 
-    final content = controller.buildContent();
     final rawText = content.text;
     final newText = rawText.trim();
     final elements = _trimmedElements(content.elements, rawText, newText);
-    controller.dispose();
 
     final oldElements = serializeFormatElements(
       message.formatRanges.where((r) => composerFormats.contains(r.format)),
@@ -6598,6 +6551,95 @@ class _ChatMessageListState extends State<_ChatMessageList> {
     return ValueListenableBuilder<int>(
       valueListenable: widget.host._messagesRev,
       builder: (context, _, _) => widget.host._buildMessagesListContent(),
+    );
+  }
+}
+
+class _EditMessageSheet extends StatefulWidget {
+  final String text;
+  final Iterable<FormatRange> formatRanges;
+  final Widget Function(
+    RichMessageController controller,
+    BuildContext context,
+    EditableTextState editableState,
+  )
+  contextMenuBuilder;
+
+  const _EditMessageSheet({
+    required this.text,
+    required this.formatRanges,
+    required this.contextMenuBuilder,
+  });
+
+  @override
+  State<_EditMessageSheet> createState() => _EditMessageSheetState();
+}
+
+class _EditMessageSheetState extends State<_EditMessageSheet> {
+  late final RichMessageController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = RichMessageController(text: widget.text)
+      ..setFormatRanges(widget.formatRanges);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 20,
+        right: 20,
+        top: 20,
+        bottom: MediaQuery.viewInsetsOf(context).bottom + 20,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Изменить сообщение',
+            style: TextStyle(
+              color: cs.onSurface,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              fontFamily: 'Outfit',
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _controller,
+            autofocus: true,
+            minLines: 1,
+            maxLines: 6,
+            style: TextStyle(color: cs.onSurface),
+            contextMenuBuilder: (ctx, state) =>
+                widget.contextMenuBuilder(_controller, ctx, state),
+            decoration: InputDecoration(
+              hintText: 'Текст сообщения',
+              filled: true,
+              fillColor: cs.surfaceContainerHighest,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(14),
+                borderSide: BorderSide.none,
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(_controller.buildContent()),
+            child: const Text('Сохранить'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/frontend/screens/chats/chat_screen.dart
+++ b/lib/frontend/screens/chats/chat_screen.dart
@@ -6620,6 +6620,7 @@ class _EditMessageSheetState extends State<_EditMessageSheet> {
             autofocus: true,
             minLines: 1,
             maxLines: 6,
+            textCapitalization: TextCapitalization.sentences,
             style: TextStyle(color: cs.onSurface),
             contextMenuBuilder: (ctx, state) =>
                 widget.contextMenuBuilder(_controller, ctx, state),

--- a/lib/frontend/widgets/attachment/attachment_sheet.dart
+++ b/lib/frontend/widgets/attachment/attachment_sheet.dart
@@ -799,6 +799,7 @@ class _AttachmentSheetState extends State<AttachmentSheet> {
                   controller: _captionCtrl,
                   style: TextStyle(color: cs.onSurface, fontSize: 15),
                   cursorColor: cs.primary,
+                  textCapitalization: TextCapitalization.sentences,
                   decoration: InputDecoration(
                     isCollapsed: true,
                     border: InputBorder.none,

--- a/lib/frontend/widgets/attachment/attachment_sheet.dart
+++ b/lib/frontend/widgets/attachment/attachment_sheet.dart
@@ -1,8 +1,11 @@
 import 'dart:io';
 
+import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import 'package:komet/core/config/app_frost.dart';
 import 'package:komet/core/config/app_nav_pill_style.dart';
@@ -177,11 +180,17 @@ class _AttachmentSheetState extends State<AttachmentSheet> {
     );
   }
 
-  void _onCameraTap() {
-    showCustomNotification(
-      context,
-      AppLocalizations.of(context)!.attachSheetCameraComingSoon,
-    );
+  Future<void> _onCameraTap() async {
+    final l10n = AppLocalizations.of(context)!;
+    XFile? shot;
+    try {
+      shot = await ImagePicker().pickImage(source: ImageSource.camera);
+    } catch (_) {
+      if (mounted) showCustomNotification(context, l10n.attachSheetCameraError);
+      return;
+    }
+    if (shot == null || !mounted) return;
+    _openPreview(CameraGalleryItem(File(shot.path)));
   }
 
   void _sendSelection({GalleryItem? fallback}) {
@@ -840,34 +849,156 @@ class _KeepAlivePageState extends State<_KeepAlivePage>
   }
 }
 
-class _CameraTile extends StatelessWidget {
+class _CameraTile extends StatefulWidget {
   final VoidCallback onTap;
   final ColorScheme cs;
 
   const _CameraTile({required this.onTap, required this.cs});
 
   @override
+  State<_CameraTile> createState() => _CameraTileState();
+}
+
+class _CameraTileState extends State<_CameraTile> with WidgetsBindingObserver {
+  CameraController? _controller;
+  bool _starting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _maybeStartPreview();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _maybeStartPreview();
+    } else if (state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.paused) {
+      _stopPreview();
+    }
+  }
+
+  Future<void> _maybeStartPreview() async {
+    if (_starting || _controller != null) return;
+    if (!(Platform.isAndroid || Platform.isIOS)) return;
+    if (!await Permission.camera.status.isGranted) return;
+    _starting = true;
+    try {
+      final cameras = await availableCameras();
+      if (cameras.isEmpty || !mounted) return;
+      final back = cameras.firstWhere(
+        (c) => c.lensDirection == CameraLensDirection.back,
+        orElse: () => cameras.first,
+      );
+      final controller = CameraController(
+        back,
+        ResolutionPreset.low,
+        enableAudio: false,
+      );
+      await controller.initialize();
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      setState(() => _controller = controller);
+    } catch (_) {
+      // keep the fallback tile
+    } finally {
+      _starting = false;
+    }
+  }
+
+  void _stopPreview() {
+    final controller = _controller;
+    if (controller == null) return;
+    _controller = null;
+    controller.dispose();
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final cs = widget.cs;
+    final controller = _controller;
+    final hasPreview = controller != null && controller.value.isInitialized;
+
     return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        color: cs.surfaceContainerHighest,
-        alignment: Alignment.center,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Symbols.photo_camera,
-              size: 34,
-              color: cs.onSurface,
-              weight: 400,
+      onTap: widget.onTap,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (hasPreview)
+            _buildPreview(controller)
+          else
+            Container(color: cs.surfaceContainerHighest),
+          if (hasPreview)
+            const DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [Color(0x00000000), Color(0x66000000)],
+                ),
+              ),
             ),
-            const SizedBox(height: 6),
-            Text(
-              AppLocalizations.of(context)!.attachSheetCamera,
-              style: TextStyle(color: cs.onSurfaceVariant, fontSize: 12),
+          Align(
+            alignment: hasPreview ? Alignment.bottomLeft : Alignment.center,
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: hasPreview
+                  ? const Icon(
+                      Symbols.photo_camera,
+                      size: 22,
+                      color: Colors.white,
+                      weight: 500,
+                    )
+                  : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Symbols.photo_camera,
+                          size: 34,
+                          color: cs.onSurface,
+                          weight: 400,
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          AppLocalizations.of(context)!.attachSheetCamera,
+                          style: TextStyle(
+                            color: cs.onSurfaceVariant,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ],
+                    ),
             ),
-          ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPreview(CameraController controller) {
+    final size = controller.value.previewSize;
+    if (size == null) {
+      return Container(color: widget.cs.surfaceContainerHighest);
+    }
+    return ClipRect(
+      child: FittedBox(
+        fit: BoxFit.cover,
+        child: SizedBox(
+          width: size.height,
+          height: size.width,
+          child: CameraPreview(controller),
         ),
       ),
     );

--- a/lib/frontend/widgets/attachment/bubbles/bubble_context.dart
+++ b/lib/frontend/widgets/attachment/bubbles/bubble_context.dart
@@ -45,8 +45,9 @@ class BubbleContext {
   static const double photoMinSize = 100.0;
   static const double photoBorderRadius = 12.0;
   static const double bubbleBorderRadius = 20.0;
-  static const double captionPaddingHorizontal = 6.0;
-  static const double captionPaddingRight = 4.0;
+  static const double captionPaddingHorizontal = 10.0;
+  static const double captionPaddingRight = 6.0;
+  static const double captionPaddingTop = 6.0;
   static const double compactTimePadding = 8.0;
 
   final BuildContext context;

--- a/lib/frontend/widgets/attachment/bubbles/photo_bubble.dart
+++ b/lib/frontend/widgets/attachment/bubbles/photo_bubble.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
@@ -52,12 +53,7 @@ class PhotoBubble extends StatelessWidget {
     }
 
     if (count == 1) {
-      final photo = photos[0];
-      final pw = photo.width?.toDouble() ?? 200;
-      final photoWidth = pw.clamp(
-        BubbleContext.photoMinSize,
-        BubbleContext.photoMaxSize,
-      );
+      final photoWidth = _displaySize(photos[0]).width;
 
       return SizedBox(
         width: photoWidth,
@@ -70,6 +66,7 @@ class PhotoBubble extends StatelessWidget {
               padding: const EdgeInsets.only(
                 left: BubbleContext.captionPaddingHorizontal,
                 right: BubbleContext.captionPaddingRight,
+                top: BubbleContext.captionPaddingTop,
                 bottom: 6,
               ),
               child: Row(
@@ -94,6 +91,7 @@ class PhotoBubble extends StatelessWidget {
           padding: const EdgeInsets.only(
             left: BubbleContext.captionPaddingHorizontal,
             right: BubbleContext.captionPaddingRight,
+            top: BubbleContext.captionPaddingTop,
             bottom: 6,
           ),
           child: Row(
@@ -108,18 +106,40 @@ class PhotoBubble extends StatelessWidget {
     );
   }
 
-  Widget _buildSinglePhoto(BubbleContext ctx, PhotoAttachment photo) {
+  Size _displaySize(PhotoAttachment photo) {
     final width = photo.width?.toDouble() ?? 200;
     final height = photo.height?.toDouble() ?? 200;
 
-    final constrainedWidth = width.clamp(
-      BubbleContext.photoMinSize,
-      BubbleContext.photoMaxSize,
+    final downScale = math.min(
+      1.0,
+      math.min(
+        BubbleContext.photoMaxSize / width,
+        BubbleContext.photoMaxSize / height,
+      ),
     );
-    final constrainedHeight = height.clamp(
-      BubbleContext.photoMinSize,
-      BubbleContext.photoMaxSize,
+    var displayWidth = width * downScale;
+    var displayHeight = height * downScale;
+
+    final upScale = math.max(
+      1.0,
+      math.max(
+        BubbleContext.photoMinSize / displayWidth,
+        BubbleContext.photoMinSize / displayHeight,
+      ),
     );
+    displayWidth *= upScale;
+    displayHeight *= upScale;
+
+    return Size(
+      displayWidth.clamp(BubbleContext.photoMinSize, BubbleContext.photoMaxSize),
+      displayHeight.clamp(BubbleContext.photoMinSize, BubbleContext.photoMaxSize),
+    );
+  }
+
+  Widget _buildSinglePhoto(BubbleContext ctx, PhotoAttachment photo) {
+    final size = _displaySize(photo);
+    final constrainedWidth = size.width;
+    final constrainedHeight = size.height;
     final dpr = MediaQuery.of(ctx.context).devicePixelRatio;
 
     final matchTop = ctx.hasPhotoWithCaption;

--- a/lib/frontend/widgets/attachment/bubbles/video_bubble.dart
+++ b/lib/frontend/widgets/attachment/bubbles/video_bubble.dart
@@ -146,6 +146,7 @@ class VideoBubble extends StatelessWidget {
             padding: const EdgeInsets.only(
               left: BubbleContext.captionPaddingHorizontal,
               right: BubbleContext.captionPaddingRight,
+              top: BubbleContext.captionPaddingTop,
               bottom: 6,
             ),
             child: Row(

--- a/lib/frontend/widgets/message_actions_overlay.dart
+++ b/lib/frontend/widgets/message_actions_overlay.dart
@@ -230,7 +230,7 @@ class _MessageActionsLayer extends StatefulWidget {
 }
 
 class _MessageActionsLayerState extends State<_MessageActionsLayer>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   late final AnimationController _animController;
   late final Animation<double> _animation;
   late final AnimationController _expandController;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -810,6 +810,7 @@
   "attachSheetGallery": "Gallery",
   "attachSheetPoll": "Poll",
   "attachSheetCameraComingSoon": "Camera is coming soon",
+  "attachSheetCameraError": "Couldn't open the camera",
   "attachSheetSendFileTitle": "Send a file",
   "attachSheetSendFileSubtitle": "A document, archive, or any other file",
   "attachSheetChooseFileButton": "Choose file",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3626,6 +3626,12 @@ abstract class AppLocalizations {
   /// **'Camera is coming soon'**
   String get attachSheetCameraComingSoon;
 
+  /// No description provided for @attachSheetCameraError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t open the camera'**
+  String get attachSheetCameraError;
+
   /// No description provided for @attachSheetSendFileTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1877,6 +1877,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get attachSheetCameraComingSoon => 'Camera is coming soon';
 
   @override
+  String get attachSheetCameraError => 'Couldn\'t open the camera';
+
+  @override
   String get attachSheetSendFileTitle => 'Send a file';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1887,6 +1887,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get attachSheetCameraComingSoon => 'Камера скоро появится';
 
   @override
+  String get attachSheetCameraError => 'Не удалось открыть камеру';
+
+  @override
   String get attachSheetSendFileTitle => 'Отправить файл';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -613,6 +613,7 @@
   "attachSheetGallery": "Галерея",
   "attachSheetPoll": "Опрос",
   "attachSheetCameraComingSoon": "Камера скоро появится",
+  "attachSheetCameraError": "Не удалось открыть камеру",
   "attachSheetSendFileTitle": "Отправить файл",
   "attachSheetSendFileSubtitle": "Документ, архив или любой другой файл",
   "attachSheetChooseFileButton": "Выбрать файл",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  camera:
+    dependency: "direct main"
+    description:
+      name: camera
+      sha256: "4142a19a38e388d3bab444227636610ba88982e36dff4552d5191a86f65dc437"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.4"
+  camera_android_camerax:
+    dependency: transitive
+    description:
+      name: camera_android_camerax
+      sha256: "8516fe308bc341a5067fb1a48edff0ddfa57c0d3cdcc9dbe7ceca3ba119e2577"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.30"
+  camera_avfoundation:
+    dependency: transitive
+    description:
+      name: camera_avfoundation
+      sha256: "11b4aee2f5e5e038982e152b4a342c749b414aa27857899d20f4323e94cb5f0b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.23+2"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      sha256: "4524ca6eb4176b066864036ad4fe02c3e4863e63b77eadc21a5bf56824f43498"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.1"
+  camera_web:
+    dependency: transitive
+    description:
+      name: camera_web
+      sha256: "1245a480a113437f8d46d19c0fb90cea9db921436d9cf2ba5fb11854a1312693"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   characters:
     dependency: transitive
     description:
@@ -297,6 +337,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.3.7"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   firebase_core:
     dependency: "direct main"
     description:
@@ -709,6 +781,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.1"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+19"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   intl:
     dependency: "direct main"
     description:
@@ -1100,6 +1236,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.10"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -1441,6 +1625,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,9 @@ dependencies:
   flutter_timezone: ^5.0.1
   timezone: ^0.11.0
   file_picker: ^8.0.0
+  image_picker: ^1.1.2
+  camera: ^0.11.0
+  permission_handler: ^11.3.1
   archive: ^4.0.9
   geolocator: ^13.0.0
   photo_manager: ^3.0.0


### PR DESCRIPTION
## Описание

Фиксы отображения фото в чате, крашей при редактировании сообщения с фото и в меню действий, автозаглавная буква при наборе и рабочая камера в шторке вложений с живым предпросмотром. Из `fix/photo-bubble-aspect-and-edit-crash` в `dev/0.5.0`.

**Объём:** 15 файлов, +531 / −94.

## Что вошло

### 💬 Чаты и сообщения
- Одиночное фото в пузыре больше не обрезается в квадрат — превью считается по реальному соотношению сторон (даунскейл до 280px по большей стороне, апскейл до 100px по меньшей); ширина блока подписи совпадает с шириной фото
- Подписи под фото и видео: верхний отступ 6px, боковые 10/6 вместо 6/4 — константы вынесены в `BubbleContext`
- Краш при редактировании сообщения с фото: `RichMessageController` уничтожался до конца анимации закрытия шторки, TextField обращался к мёртвому контроллеру («used after being disposed» → каскадный ассерт `_dependents.isEmpty`); шторка выделена в `_EditMessageSheet`, который владеет контроллером и освобождает его в `dispose`
- Краш меню действий при тапе над открытой клавиатурой: `_MessageActionsLayerState` создавал два `AnimationController` при `SingleTickerProviderStateMixin`; заменён на `TickerProviderStateMixin`
- `TextCapitalization.sentences` в композере, подписи к вложениям и шторке редактирования — клавиатура сама предлагает заглавную в начале предложения
- Камера в шторке вложений работает вместо заглушки «скоро появится»: тап делает снимок через системную камеру (`image_picker`); при выданном разрешении плитка показывает живой предпросмотр с задней камеры (`camera`/CameraX) с освобождением при сворачивании приложения, статус разрешения проверяется молча (`permission_handler`)

## Коммиты

- `c5b5635` fix(chat): фото в пузырях сохраняют пропорции, подписи получили отступы
- `7329167` fix(chat): краш при редактировании сообщения с фото
- `4ac5637` feat(chat): автозаглавная буква в начале предложений при наборе
- `868b1e2` fix(chat): краш меню действий над клавиатурой из-за одиночного тикера
- `116ff19` feat(chat): камера в шторке вложений — съёмка и живой предпросмотр

## Проверка

- [x] `flutter analyze`
- [x] Сборка `komet` flavor
- [x] Ручная проверка: фото разных пропорций с подписью и без, редактирование сообщения с фото, автозаглавная буква, меню действий над клавиатурой, съёмка и живой предпросмотр камеры (Pixel 9 Pro, debug)